### PR TITLE
sortmergeterms namespace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorMPS"
 uuid = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 ITensorTDVP = "25707e16-a4db-4a07-99d9-4d67b7af0342"

--- a/src/ITensorMPS.jl
+++ b/src/ITensorMPS.jl
@@ -3,6 +3,8 @@ using Reexport: @reexport
 @reexport using ITensorTDVP: TimeDependentSum, dmrg_x, linsolve, tdvp, to_vec
 using ITensorTDVP: ITensorTDVP
 const alternating_update_dmrg = ITensorTDVP.dmrg
+# Not re-exported, but accessible as `ITensorMPS.sortmergeterms`.
+using ITensors.ITensorMPS: sortmergeterms
 @reexport using ITensors.ITensorMPS:
   @OpName_str,
   @SiteType_str,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using ITensorMPS: ITensorMPS
 using ITensorTDVP: ITensorTDVP
 using ITensors: ITensors
 include("utils/TestITensorMPSExportedNames.jl")
-using Test: @test, @testset
+using Test: @test, @test_broken, @testset
 @testset "ITensorMPS.jl" begin
   @testset "exports" begin
     @test issetequal(
@@ -17,8 +17,17 @@ using Test: @test, @testset
       ],
     )
   end
-  @testset "aliases" begin
+  @testset "Aliases" begin
     @test ITensorMPS.alternating_update_dmrg === ITensorTDVP.dmrg
+  end
+  @testset "Not exported" begin
+    @test ITensorMPS.sortmergeterms === ITensors.ITensorMPS.sortmergeterms
+    # Should we fix this in ITensors.jl by adding:
+    # ```julia
+    # using .ITensorMPS: sortmergeterms
+    # ```
+    # ?
+    @test_broken ITensorMPS.sortmergeterms === ITensors.sortmergeterms
   end
 end
 end


### PR DESCRIPTION
This makes `ITensors.ITensorMPS.sortmergeterms` accessible as `ITensorMPS.sortmergeterms`, which some packages like `ITensorChemstry.jl` are relying on (caught by a test failure in https://github.com/mtfishman/ITensorChemistry.jl/pull/12).