### PR TITLE
Make ProjMPS accessible

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorMPS"
 uuid = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 ITensorTDVP = "25707e16-a4db-4a07-99d9-4d67b7af0342"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorMPS"
 uuid = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 ITensorTDVP = "25707e16-a4db-4a07-99d9-4d67b7af0342"

--- a/src/ITensorMPS.jl
+++ b/src/ITensorMPS.jl
@@ -3,8 +3,9 @@ using Reexport: @reexport
 @reexport using ITensorTDVP: TimeDependentSum, dmrg_x, linsolve, tdvp, to_vec
 using ITensorTDVP: ITensorTDVP
 const alternating_update_dmrg = ITensorTDVP.dmrg
-# Not re-exported, but accessible as `ITensorMPS.sortmergeterms`.
-using ITensors.ITensorMPS: sortmergeterms
+# Not re-exported, but this makes these types and functions accessible
+# as `ITensorMPS.x`.
+using ITensors.ITensorMPS: AbstractSum, sortmergeterms
 @reexport using ITensors.ITensorMPS:
   @OpName_str,
   @SiteType_str,

--- a/src/ITensorMPS.jl
+++ b/src/ITensorMPS.jl
@@ -5,7 +5,7 @@ using ITensorTDVP: ITensorTDVP
 const alternating_update_dmrg = ITensorTDVP.dmrg
 # Not re-exported, but this makes these types and functions accessible
 # as `ITensorMPS.x`.
-using ITensors.ITensorMPS: AbstractSum, sortmergeterms
+using ITensors.ITensorMPS: AbstractSum, ProjMPS, sortmergeterms
 @reexport using ITensors.ITensorMPS:
   @OpName_str,
   @SiteType_str,
@@ -38,7 +38,6 @@ using ITensors.ITensorMPS: AbstractSum, sortmergeterms
   ProjMPO,
   ProjMPOSum,
   ProjMPO_MPS,
-  ProjMPS,
   Scaled,
   SiteType,
   Spectrum,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,7 @@ using Test: @test, @test_broken, @testset
     # ```
     # ?
     @test_broken ITensorMPS.sortmergeterms === ITensors.sortmergeterms
+    @test ITensorMPS.AbstractSum === ITensors.ITensorMPS.AbstractSum
   end
 end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,7 @@ using Test: @test, @test_broken, @testset
     # ?
     @test_broken ITensorMPS.sortmergeterms === ITensors.sortmergeterms
     @test ITensorMPS.AbstractSum === ITensors.ITensorMPS.AbstractSum
+    @test ITensorMPS.ProjMPS === ITensors.ITensorMPS.ProjMPS
   end
 end
 end


### PR DESCRIPTION
Adds `ProjMPS` to the list of exports. This is needed by other packages such as `ITensorQTT`. I tried just writing `ITensorMPS.ProjMPS` but I believe since the `ITensorMPS` package only does reexports, unexported methods may not be accessible through `ITensorMPS`.
