### PR TITLE
Make more ITensorMPS internals visible

### DIFF
--- a/src/ITensorMPS.jl
+++ b/src/ITensorMPS.jl
@@ -5,7 +5,8 @@ using ITensorTDVP: ITensorTDVP
 const alternating_update_dmrg = ITensorTDVP.dmrg
 # Not re-exported, but this makes these types and functions accessible
 # as `ITensorMPS.x`.
-using ITensors.ITensorMPS: AbstractSum, ProjMPS, sortmergeterms
+using ITensors.ITensorMPS:
+  AbstractProjMPO, AbstractSum, ProjMPS, makeL!, makeR!, sortmergeterms
 @reexport using ITensors.ITensorMPS:
   @OpName_str,
   @SiteType_str,


### PR DESCRIPTION
This PR makes a few more ITensorMPS internal types and methods visible, in order for the `ITensorQTT` package tests to pass. They now pass so this should be all of these needed for that package.
