### PR TITLE
Define ITensorMPS.Experimental.dmrg

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorMPS"
 uuid = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 ITensorTDVP = "25707e16-a4db-4a07-99d9-4d67b7af0342"

--- a/src/Deprecated.jl
+++ b/src/Deprecated.jl
@@ -1,0 +1,3 @@
+module Deprecated
+using ITensors.ITensorMPS: dmrg
+end

--- a/src/Experimental.jl
+++ b/src/Experimental.jl
@@ -1,0 +1,3 @@
+module Experimental
+using ITensorTDVP: dmrg
+end

--- a/src/ITensorMPS.jl
+++ b/src/ITensorMPS.jl
@@ -1,12 +1,15 @@
 module ITensorMPS
 using Reexport: @reexport
 @reexport using ITensorTDVP: TimeDependentSum, dmrg_x, linsolve, tdvp, to_vec
-using ITensorTDVP: ITensorTDVP
-const alternating_update_dmrg = ITensorTDVP.dmrg
 # Not re-exported, but this makes these types and functions accessible
 # as `ITensorMPS.x`.
 using ITensors.ITensorMPS:
   AbstractProjMPO, AbstractSum, ProjMPS, makeL!, makeR!, set_terms, sortmergeterms, terms
+include("Experimental.jl")
+using .Experimental: Experimental
+include("Deprecated.jl")
+using .Deprecated: Deprecated, dmrg
+export dmrg
 @reexport using ITensors.ITensorMPS:
   @OpName_str,
   @SiteType_str,
@@ -63,7 +66,6 @@ using ITensors.ITensorMPS:
   cutoff,
   cutoff!, # deprecate
   disk,
-  dmrg,
   dot, # remove export
   eigs, # deprecate
   energies, # deprecate

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,8 @@ using Test: @test, @test_broken, @testset
     )
   end
   @testset "Aliases" begin
-    @test ITensorMPS.alternating_update_dmrg === ITensorTDVP.dmrg
+    @test ITensorMPS.Experimental.dmrg === ITensorTDVP.dmrg
+    @test ITensorMPS.dmrg === ITensors.ITensorMPS.dmrg
   end
   @testset "Not exported" begin
     @test ITensorMPS.sortmergeterms === ITensors.ITensorMPS.sortmergeterms


### PR DESCRIPTION
Rename `ITensorMPS.alternating_update_dmrg` to `ITensorMPS.Experimental.dmrg`, and move `ITensors.ITensorMPS.dmrg` into `ITensorMPS.Deprecated` (but still export it for now).