### PR TITLE
Bump to ITensorTDVP.jl v0.4, ITensorMPS.jl v0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorMPS"
 uuid = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.1.8"
+version = "0.2.0"
 
 [deps]
 ITensorTDVP = "25707e16-a4db-4a07-99d9-4d67b7af0342"
@@ -9,7 +9,7 @@ ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-ITensorTDVP = "0.3"
+ITensorTDVP = "0.4"
 ITensors = "0.3, 0.4, 0.5, 0.6"
 Reexport = "1"
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ See the [ITensor documentation](https://itensor.github.io/ITensors.jl/dev) for g
 ## Upgrade guide
 
 The goal will be to move the MPS and MPO code from the ITensors.jl package, along with all of the code from the [ITensorTDVP.jl](https://github.com/ITensor/ITensorTDVP.jl) package, into this repository. If you are using any MPS/MPO functionality of ITensors.jl, such as the `MPS` and `MPO` types or constructors thereof (like `randomMPS`), `OpSum`, `siteinds`, `dmrg`, `apply`, etc. you should install the ITensorMPS.jl package with `import Pkg; Pkg.add("ITensorMPS")` and add `using ITensorMPS` to your code. Additionally, if you are currently using [ITensorTDVP.jl](https://github.com/ITensor/ITensorTDVP.jl), you should replace `using ITensorTDVP` with `using ITensorMPS` in your codes.
+
+## News
+
+### ITensorMPS.jl v0.2 release notes
+
+ITensorMPS.jl v0.2 has been released, which is a breaking release. It updates to using ITensorTDVP.jl v0.4, which has a number of breaking changes to the `tdvp`, `linsolve`, and `dmrg_x` functions. See the [ITensorTDVP.jl v0.4 release notes](https://github.com/ITensor/ITensorTDVP.jl/blob/main/README.md#itensortdvpjl-v04-release-notes) for details.


### PR DESCRIPTION
Bump to ITensorTDVP.jl v0.4 (https://github.com/ITensor/ITensorTDVP.jl/pull/74) which has many breaking changes. Release a new ITensorMPS.jl v0.2 since functions like `tdvp` and `linsolve` are re-exported by ITensorMPS.jl from ITensorTDVP.jl and have breaking changes.