### PR TITLE
Fix `ops` reexport

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorMPS"
 uuid = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 ITensorTDVP = "25707e16-a4db-4a07-99d9-4d67b7af0342"

--- a/src/ITensorMPS.jl
+++ b/src/ITensorMPS.jl
@@ -10,7 +10,9 @@ using .Experimental: Experimental
 include("Deprecated.jl")
 using .Deprecated: Deprecated, dmrg
 export dmrg
-@reexport using ITensors: contract
+# `ops` is defined in `ITensors.SiteTypes`.
+# TODO: Maybe reexport from there.
+@reexport using ITensors: contract, ops
 @reexport using ITensors.ITensorMPS:
   @OpName_str,
   @SiteType_str,
@@ -117,7 +119,6 @@ export dmrg
   nsite,
   nsweep,
   op,
-  ops,
   orthoCenter,
   ortho_lims,
   orthocenter,


### PR DESCRIPTION
Fixes the issue brought up in https://itensor.discourse.group/t/ops-bug-with-itensormps/1948.

The issue was that `ITensorMPS` was accidentally reexporting `ITensors.ITensorMPS.ops`, which is a function defined for observers, instead of `ITensors.SiteTypes.ops`.