### PR TITLE
Output truncation error from `truncate!`

### DIFF
--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -1672,7 +1672,7 @@ provided as keyword arguments.
 
 Keyword arguments:
 * `site_range`=1:N - only truncate the MPS bonds between these sites
-* `truncation_errors` - if provided, will store the truncation error from each SVD performed in a single call to `truncate!`. This should be a `Ref` type, for example `truncation_errors = Ref{Vector{Float64}}()`. It should be initialized to some value (likely 0.0, e.g., `truncation_errors[] = zeros(nbonds)`).
+* `truncation_errors!` - if provided, will store the truncation error from each SVD performed in a single call to `truncate!`. This should be a `Ref` type, for example `truncation_errors! = Ref{Vector{Float64}}()`, which will be overwritten in the function.
 """
 function truncate!(M::AbstractMPS; alg="frobenius", kwargs...)
   return truncate!(Algorithm(alg), M; kwargs...)
@@ -1682,7 +1682,7 @@ function truncate!(
   ::Algorithm"frobenius",
   M::AbstractMPS;
   site_range=1:length(M),
-  truncation_errors=nothing,
+  (truncation_errors!)=nothing,
   kwargs...,
 )
   N = length(M)
@@ -1692,7 +1692,9 @@ function truncate!(
   orthogonalize!(M, last(site_range))
 
   # Perform truncations in a right-to-left sweep
-  for (i,j) in enumerate(reverse((first(site_range) + 1):last(site_range)))
+  js = reverse((first(site_range) + 1):last(site_range))
+  for i in eachindex(js)
+    j = js[i]
     rinds = uniqueinds(M[j], M[j - 1])
     ltags = tags(commonind(M[j], M[j - 1]))
     U, S, V, spec = svd(M[j], rinds; lefttags=ltags, kwargs...)

--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -1682,7 +1682,7 @@ function callback(; link, truncation_error)
   truncation_errors[bond_no] = truncation_error
   return nothing
 end
-truncate!(ψ; maxdim=5, cutoff=1E-7, callback=callback)
+truncate!(ψ; maxdim=5, cutoff=1E-7, callback)
 ```
 """
 function truncate!(M::AbstractMPS; alg="frobenius", kwargs...)

--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -1672,13 +1672,18 @@ provided as keyword arguments.
 
 Keyword arguments:
 * `site_range`=1:N - only truncate the MPS bonds between these sites
+* `truncation_error` - if provided, will store the truncation error from all SVDs performed in a single call to `truncate!`. This should be a `Ref` type, for example `truncation_error = Ref{Float64}()`. It should be initialized to some value (likely 0.0, e.g., `truncation_error[] = 0.0`).
 """
 function truncate!(M::AbstractMPS; alg="frobenius", kwargs...)
   return truncate!(Algorithm(alg), M; kwargs...)
 end
 
 function truncate!(
-  ::Algorithm"frobenius", M::AbstractMPS; site_range=1:length(M), kwargs...
+  ::Algorithm"frobenius",
+  M::AbstractMPS;
+  site_range=1:length(M),
+  truncation_error=nothing,
+  kwargs...,
 )
   N = length(M)
 
@@ -1690,7 +1695,10 @@ function truncate!(
   for j in reverse((first(site_range) + 1):last(site_range))
     rinds = uniqueinds(M[j], M[j - 1])
     ltags = tags(commonind(M[j], M[j - 1]))
-    U, S, V = svd(M[j], rinds; lefttags=ltags, kwargs...)
+    U, S, V, spec = svd(M[j], rinds; lefttags=ltags, kwargs...)
+    if !isnothing(truncation_error)
+      truncation_error[] += spec.truncerr
+    end
     M[j] = U
     M[j - 1] *= (S * V)
     setrightlim!(M, j)

--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -1701,9 +1701,7 @@ function truncate!(
   orthogonalize!(M, last(site_range))
 
   # Perform truncations in a right-to-left sweep
-  js = reverse((first(site_range) + 1):last(site_range))
-  for i in eachindex(js)
-    j = js[i]
+  for j in reverse((first(site_range) + 1):last(site_range))
     rinds = uniqueinds(M[j], M[j - 1])
     ltags = tags(commonind(M[j], M[j - 1]))
     U, S, V, spec = svd(M[j], rinds; lefttags=ltags, kwargs...)

--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -1682,7 +1682,7 @@ function callback!(; link, truncation_error)
   truncation_errors[bond_no] = truncation_error
   return nothing
 end
-truncate!(ψ, maxdim=5, cutoff=1E-7, (callback!)=callback!)
+truncate!(ψ; maxdim=5, cutoff=1E-7, callback!)
 ```
 """
 function truncate!(M::AbstractMPS; alg="frobenius", kwargs...)

--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -1672,7 +1672,18 @@ provided as keyword arguments.
 
 Keyword arguments:
 * `site_range`=1:N - only truncate the MPS bonds between these sites
-* `truncation_error=false` - If `true`, will return a vector containing the trucation error calculated at each bond.
+* `(callback!)=Returns(nothing)` - callback function that allows the user to save the per-bond truncation error. The API of `callback!` expects to take two kwargs called `link` and `truncation_error` where `link` is of type `Pair{Int64, Int64}` and `truncation_error` is `Float64`. Consider the following example that illustrates one possible use case.
+
+```julia
+nbonds = 9
+truncation_errors = zeros(nbonds)
+function callback!(; link, truncation_error)
+  bond_no = last(link)
+  truncation_errors[bond_no] = truncation_error
+  return nothing
+end
+truncate!(ψ, maxdim=5, cutoff=1E-7, (callback!)=callback!)
+```
 """
 function truncate!(M::AbstractMPS; alg="frobenius", kwargs...)
   return truncate!(Algorithm(alg), M; kwargs...)
@@ -1682,12 +1693,9 @@ function truncate!(
   ::Algorithm"frobenius",
   M::AbstractMPS;
   site_range=1:length(M),
-  truncation_error = false,
+  (callback!)=Returns(nothing),
   kwargs...,
 )
-  N = length(M)
-  nbonds = N - 1
-  truncation_errors = zeros(real(scalartype(M)), nbonds)
   # Left-orthogonalize all tensors to make
   # truncations controlled
   orthogonalize!(M, last(site_range))
@@ -1699,16 +1707,12 @@ function truncate!(
     rinds = uniqueinds(M[j], M[j - 1])
     ltags = tags(commonind(M[j], M[j - 1]))
     U, S, V, spec = svd(M[j], rinds; lefttags=ltags, kwargs...)
-    truncation_errors[i] = spec.truncerr
     M[j] = U
     M[j - 1] *= (S * V)
     setrightlim!(M, j)
+    callback!(; link=(j => j - 1), truncation_error=spec.truncerr)
   end
-  if truncation_error
-    return truncation_errors
-  else
-    return M
-  end
+  return M
 end
 
 function truncate(ψ0::AbstractMPS; kwargs...)

--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -1672,17 +1672,17 @@ provided as keyword arguments.
 
 Keyword arguments:
 * `site_range`=1:N - only truncate the MPS bonds between these sites
-* `(callback!)=Returns(nothing)` - callback function that allows the user to save the per-bond truncation error. The API of `callback!` expects to take two kwargs called `link` and `truncation_error` where `link` is of type `Pair{Int64, Int64}` and `truncation_error` is `Float64`. Consider the following example that illustrates one possible use case.
+* `callback=Returns(nothing)` - callback function that allows the user to save the per-bond truncation error. The API of `callback` expects to take two kwargs called `link` and `truncation_error` where `link` is of type `Pair{Int64, Int64}` and `truncation_error` is `Float64`. Consider the following example that illustrates one possible use case.
 
 ```julia
 nbonds = 9
 truncation_errors = zeros(nbonds)
-function callback!(; link, truncation_error)
+function callback(; link, truncation_error)
   bond_no = last(link)
   truncation_errors[bond_no] = truncation_error
   return nothing
 end
-truncate!(ψ; maxdim=5, cutoff=1E-7, callback!)
+truncate!(ψ; maxdim=5, cutoff=1E-7, callback=callback)
 ```
 """
 function truncate!(M::AbstractMPS; alg="frobenius", kwargs...)
@@ -1693,7 +1693,7 @@ function truncate!(
   ::Algorithm"frobenius",
   M::AbstractMPS;
   site_range=1:length(M),
-  (callback!)=Returns(nothing),
+  callback=Returns(nothing),
   kwargs...,
 )
   # Left-orthogonalize all tensors to make
@@ -1708,7 +1708,7 @@ function truncate!(
     M[j] = U
     M[j - 1] *= (S * V)
     setrightlim!(M, j)
-    callback!(; link=(j => j - 1), truncation_error=spec.truncerr)
+    callback(; link=(j => j - 1), truncation_error=spec.truncerr)
   end
   return M
 end

--- a/test/base/test_mps.jl
+++ b/test/base/test_mps.jl
@@ -756,16 +756,19 @@ end
     @test linkdims(M) == [2, 4, 2, 2, 2, 2, 8, 4, 2]
   end
 
-  @testset "truncate! with truncation_error" begin
+  @testset "truncate! with callback!" begin
     nsites = 10
     nbonds = nsites - 1
     mps_ = basicRandomMPS(nsites; dim=10)
-    truncation_errors = truncate!(mps_, maxdim=3, cutoff=1E-3, truncation_error=true)
-    @test length(truncation_errors) == nbonds
+    truncation_errors = ones(nbonds) * -1.0
+    function _callback!(; link, truncation_error)
+      bond_no = last(link)
+      truncation_errors[bond_no] = truncation_error
+      return nothing
+    end
+    truncate!(mps_; maxdim=3, cutoff=1E-3, (callback!)=_callback!)
     @test all(truncation_errors .>= 0.0)
   end
-
-
 end
 
 @testset "Other MPS methods" begin

--- a/test/base/test_mps.jl
+++ b/test/base/test_mps.jl
@@ -756,12 +756,14 @@ end
     @test linkdims(M) == [2, 4, 2, 2, 2, 2, 8, 4, 2]
   end
 
-  @testset "truncate! with truncation_error" begin
+  @testset "truncate! with truncation_errors" begin
+    N = 10
+    nbonds = N - 1
     M = basicRandomMPS(10; dim=10)
-    truncation_error = Ref{Float64}()
-    truncation_error[] = 0.0
-    truncate!(M, maxdim=3, cutoff=1E-3, truncation_error=truncation_error)
-    @test truncation_error[] > 0.0
+    truncation_errors = Ref{Vector{Float64}}()
+    truncation_errors[] = fill(-1.0, nbonds) # set to something other than zero for test.
+    truncate!(M, maxdim=3, cutoff=1E-3, truncation_errors=truncation_errors)
+    @test all(truncation_errors[] .>= 0.0)
   end
 
 

--- a/test/base/test_mps.jl
+++ b/test/base/test_mps.jl
@@ -756,14 +756,13 @@ end
     @test linkdims(M) == [2, 4, 2, 2, 2, 2, 8, 4, 2]
   end
 
-  @testset "truncate! with truncation_errors" begin
-    N = 10
-    nbonds = N - 1
-    M = basicRandomMPS(10; dim=10)
-    truncation_errors = Ref{Vector{Float64}}()
-    truncation_errors[] = fill(-1.0, nbonds) # set to something other than zero for test.
-    truncate!(M, maxdim=3, cutoff=1E-3, truncation_errors=truncation_errors)
-    @test all(truncation_errors[] .>= 0.0)
+  @testset "truncate! with truncation_error" begin
+    nsites = 10
+    nbonds = nsites - 1
+    mps_ = basicRandomMPS(nsites; dim=10)
+    truncation_errors = truncate!(mps_, maxdim=3, cutoff=1E-3, truncation_error=true)
+    @test length(truncation_errors) == nbonds
+    @test all(truncation_errors .>= 0.0)
   end
 
 

--- a/test/base/test_mps.jl
+++ b/test/base/test_mps.jl
@@ -756,18 +756,18 @@ end
     @test linkdims(M) == [2, 4, 2, 2, 2, 2, 8, 4, 2]
   end
 
-  @testset "truncate! with callback!" begin
+  @testset "truncate! with callback" begin
     nsites = 10
     nbonds = nsites - 1
     s = siteinds("S=1/2", nsites)
     mps_ = random_mps(s; linkdims=10)
     truncation_errors = ones(nbonds) * -1.0
-    function _callback!(; link, truncation_error)
+    function _callback(; link, truncation_error)
       bond_no = last(link)
       truncation_errors[bond_no] = truncation_error
       return nothing
     end
-    truncate!(mps_; maxdim=3, cutoff=1E-3, (callback!)=_callback!)
+    truncate!(mps_; maxdim=3, cutoff=1E-3, callback=_callback)
     @test all(truncation_errors .>= 0.0)
   end
 end

--- a/test/base/test_mps.jl
+++ b/test/base/test_mps.jl
@@ -759,7 +759,7 @@ end
   @testset "truncate! with callback!" begin
     nsites = 10
     nbonds = nsites - 1
-    mps_ = basicRandomMPS(nsites; dim=10)
+    mps_ = random_mps(nsites; linkdims=10)
     truncation_errors = ones(nbonds) * -1.0
     function _callback!(; link, truncation_error)
       bond_no = last(link)

--- a/test/base/test_mps.jl
+++ b/test/base/test_mps.jl
@@ -759,7 +759,8 @@ end
   @testset "truncate! with callback!" begin
     nsites = 10
     nbonds = nsites - 1
-    mps_ = random_mps(nsites; linkdims=10)
+    s = siteinds("S=1/2", nsites)
+    mps_ = random_mps(s; linkdims=10)
     truncation_errors = ones(nbonds) * -1.0
     function _callback!(; link, truncation_error)
       bond_no = last(link)

--- a/test/base/test_mps.jl
+++ b/test/base/test_mps.jl
@@ -755,6 +755,16 @@ end
     truncate!(M; site_range=3:7, maxdim=2)
     @test linkdims(M) == [2, 4, 2, 2, 2, 2, 8, 4, 2]
   end
+
+  @testset "truncate! with truncation_error" begin
+    M = basicRandomMPS(10; dim=10)
+    truncation_error = Ref{Float64}()
+    truncation_error[] = 0.0
+    truncate!(M, maxdim=3, cutoff=1E-3, truncation_error=truncation_error)
+    @test truncation_error[] > 0.0
+  end
+
+
 end
 
 @testset "Other MPS methods" begin


### PR DESCRIPTION
The purpose of this commit is to allow the user to access the truncation error that is internally calculated in a call to `truncate!`. This PR implements #96. 

I have implemented this by allowing the user to pass a Ref object to the call to `truncate!`. The result of each SVD performed during a call to `truncate!` is then accumulated in that Ref. 

I also added a new test for this functionality. I then re-ran all tests.  There were 75165 passing and 33 broken for a total of 75198 tests. I also updated the docstring for `truncate!` to reflect this new keyword argument.

Here is an example of the new functionality.

A few differences with what was suggested in #96:
  - I accumulate the error rather than storing the truncation error for each bond individually.
  - I did not use the `!` in my keyword argument. Was that just for stylistic reasons or is there some other convention for doing that (I'm aware of the convention in function names but not in variable names)?

```julia
truncation_error = Ref{Float64}()
truncation_error[] = 0.0
truncate!(someMPS, maxdim=4, cutoff=1E-5, truncation_error=truncation_error)
truncation_error[]
```