### PR TITLE
replace !isapprox 0

### DIFF
--- a/src/solvers/tdvp.jl
+++ b/src/solvers/tdvp.jl
@@ -31,7 +31,7 @@ end
 function time_step_and_nsteps(t, time_step, nsteps::Nothing)
   nsteps_float = t / time_step
   nsteps_rounded = round(nsteps_float)
-  if abs(nsteps_float - nsteps_rounded) ≉ 0
+  if nsteps_float ≉ nsteps_rounded
     return error("`t / time_step = $t / $time_step = $(t / time_step)` must be an integer.")
   end
   return time_step, Int(nsteps_rounded)


### PR DESCRIPTION
As stated in the last paragraph of [the documentation for `Base.isapprox`](https://docs.julialang.org/en/v1/base/math/#Base.isapprox), `isapprox(x, 0)` behaves like `x == 0`, making it unsuitable for floating-point comparisons. Using `LHS !isapprox RHS` (as a pseudocode) will provide the expected behavior.

## Why this is needed

`time_step_and_nsteps` called from `tdvp` raised an error with, e.g., `time_stop` = `0.3` and `time_step` = `0.1`.

You can see this error with

```julia
using ITensorMPS
time_stop = 0.3
time_step = 0.1
ITensorMPS.time_step_and_nsteps(time_stop, time_step, nothing)
```

The error message is
```julia
ERROR: LoadError: `t / time_step = 0.3 / 0.1 = 2.9999999999999996` must be an integer.
```

No error is expected.

## Testing

The test command I used is

```sh
cd ITensorMPS.jl/test
julia --project runtests.jl
```

| Test Summary | Pass | Broken | Total | Time |
|:--|:-:|:-:|:-:|:-:|
| ITensor/ITensorMPS.jl/test | 75159 | 33 | 75192 | 15m10.2s |
| ultimatile/ITensorMPS.jl/test | 75159 | 33 | 75192 | 77m56.6s |

Because the number of broken tests remained unchanged between the original and modified code, I believe I did not introduce any new bugs.