### PR TITLE
Better error message for bad time step inputs

### DIFF
--- a/src/solvers/tdvp.jl
+++ b/src/solvers/tdvp.jl
@@ -34,6 +34,11 @@ function time_step_and_nsteps(t, time_step, nsteps::Nothing)
   if nsteps_float ≉ nsteps_rounded
     return error("`t / time_step = $t / $time_step = $(t / time_step)` must be an integer.")
   end
+  if real(nsteps_rounded) < 0
+    return error(
+      "computed number of steps is negative ($nsteps_rounded), check that total time ($t) and time step ($time_step) signs agree",
+    )
+  end
   return time_step, Int(nsteps_rounded)
 end
 

--- a/test/base/test_solvers/test_tdvp.jl
+++ b/test/base/test_solvers/test_tdvp.jl
@@ -38,6 +38,15 @@ const elts = (Float32, Float64, Complex{Float32}, Complex{Float64})
   @test norm(ψ2) ≈ 1 rtol = √eps(real(elt)) * 10
   # Should rotate back to original state:
   @test abs(inner(ψ0, ψ2)) > 0.99
+
+  @testset "Failure mode tests" begin
+    total_time = elt(0.1) * im
+    # matching total time and time step directions
+    @test_throws "signs agree" tdvp(H, -total_time, ψ0; time_step)
+    @test_throws "signs agree" tdvp(H, total_time, ψ0; time_step=-time_step)
+    # total time is an integer of time steps
+    @test_throws "integer" tdvp(H, total_time * 1.5, ψ0; time_step)
+  end
 end
 
 @testset "TDVP: Sum of Hamiltonians (eltype=$elt)" for elt in elts


### PR DESCRIPTION
Closes #111, makes sure the number of steps passed to alternating update is positive 