### PR TITLE
Fix Issue#104

### DIFF
--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -1906,8 +1906,9 @@ function setindex!(
       end
     end
   end
+  linktags=[defaultlinktags(i) for i in firstsite:(lastsite - 1)]
 
-  ψA = MPST(A, sites; leftinds=lind, orthocenter=orthocenter - first(r) + 1, kwargs...)
+  ψA = MPST(A, sites; leftinds=lind, orthocenter=orthocenter - first(r) + 1, tags=linktags, kwargs...)
   #@assert prod(ψA) ≈ A
 
   ψ[firstsite:lastsite] = ψA
@@ -1946,7 +1947,11 @@ by site according to the site indices `sites`.
 - `maxdim`: the maximum link dimension.
 """
 function (::Type{MPST})(
-  A::ITensor, sites; leftinds=nothing, orthocenter::Integer=length(sites), kwargs...
+  A::ITensor, sites; 
+  leftinds=nothing, 
+  orthocenter::Integer=length(sites), 
+  tags::Vector{TagSet}=[defaultlinktags(i) for i in 1:(length(sites)-1)], 
+  kwargs...
 ) where {MPST<:AbstractMPS}
   N = length(sites)
   for s in sites
@@ -1967,7 +1972,7 @@ function (::Type{MPST})(
     if !isnothing(l)
       Lis = unioninds(Lis, l)
     end
-    L, R = factorize(Ã, Lis; kwargs..., tags="Link,n=$n", ortho="left")
+    L, R = factorize(Ã, Lis; kwargs..., tags=tags[n], ortho="left")
     l = commonind(L, R)
     ψ[n] = L
     Ã = R


### PR DESCRIPTION
Added keyword `tags` to 
```
function (::Type{MPST})(
  A::ITensor, sites; 
  leftinds=nothing, 
  orthocenter::Integer=length(sites), 
  tags::Vector{TagSet}=[defaultlinktags(i) for i in 1:(length(sites)-1)], 
  kwargs...
) where {MPST<:AbstractMPS}
```
Allowing to pass the tags to use in the factorization, using `defaultlinktags` by default.
Then changed the function 
```
function setindex!(
  ψ::MPST,
  A::ITensor,
  r::UnitRange{Int};
  orthocenter::Integer=last(r),
  perm=nothing,
  kwargs...,
) where {MPST<:AbstractMPS}
```
To pass the correct linktags to the previous function. i.e.

```
  linktags=[defaultlinktags(i) for i in firstsite:(lastsite - 1)]

  ψA = MPST(A, sites; leftinds=lind, orthocenter=orthocenter - first(r) + 1, tags=linktags, kwargs...)

  ψ[firstsite:lastsite] = ψA

```

It can be tested that `@assert hasdefaultlinktags(ψ)` is valid
