### PR TITLE
Use default link tags in `movesites`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorMPS"
 uuid = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.3.16"
+version = "0.3.17"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -1950,6 +1950,10 @@ by site according to the site indices `sites`.
    in `sites` and `leftinds` will be dangling off of the right side of the MPS/MPO.
 - `orthocenter::Integer = length(sites)`: the desired final orthogonality
    center of the output MPS/MPO.
+- `tags::Vector{TagSet} = [defaultlinktags(i) for i in 1:(length(sites) - 1)]`:
+   the tags to use for the link indices. The length of `tags` must be
+   `length(sites) - 1`. The default is to use the default link tags for each
+   site.
 - `cutoff`: the desired truncation error at each link.
 - `maxdim`: the maximum link dimension.
 """

--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -1955,7 +1955,7 @@ by site according to the site indices `sites`.
    in `sites` and `leftinds` will be dangling off of the right side of the MPS/MPO.
 - `orthocenter::Integer = length(sites)`: the desired final orthogonality
    center of the output MPS/MPO.
-- `tags::Vector{TagSet} = [defaultlinktags(i) for i in 1:(length(sites) - 1)]`:
+- `tags = [defaultlinktags(i) for i in 1:(length(sites) - 1)]`:
    the tags to use for the link indices. The length of `tags` must be
    `length(sites) - 1`. The default is to use the default link tags for each
    site.
@@ -1967,7 +1967,7 @@ function (::Type{MPST})(
   sites;
   leftinds=nothing,
   orthocenter::Integer=length(sites),
-  tags::Vector{TagSet}=[defaultlinktags(i) for i in 1:(length(sites) - 1)],
+  tags=[defaultlinktags(i) for i in 1:(length(sites) - 1)],
   kwargs...,
 ) where {MPST<:AbstractMPS}
   N = length(sites)

--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -1907,7 +1907,15 @@ function setindex!(
     end
   end
 
-  ψA = MPST(A, sites; leftinds=lind, orthocenter=orthocenter - first(r) + 1, kwargs...)
+  linktags = [defaultlinktags(i) for i in firstsite:(lastsite - 1)]
+  ψA = MPST(
+    A,
+    sites;
+    leftinds=lind,
+    orthocenter=orthocenter - first(r) + 1,
+    tags=linktags,
+    kwargs...,
+  )
   #@assert prod(ψA) ≈ A
 
   ψ[firstsite:lastsite] = ψA
@@ -1946,7 +1954,12 @@ by site according to the site indices `sites`.
 - `maxdim`: the maximum link dimension.
 """
 function (::Type{MPST})(
-  A::ITensor, sites; leftinds=nothing, orthocenter::Integer=length(sites), kwargs...
+  A::ITensor,
+  sites;
+  leftinds=nothing,
+  orthocenter::Integer=length(sites),
+  tags::Vector{TagSet}=[defaultlinktags(i) for i in 1:(length(sites) - 1)],
+  kwargs...,
 ) where {MPST<:AbstractMPS}
   N = length(sites)
   for s in sites
@@ -1967,7 +1980,7 @@ function (::Type{MPST})(
     if !isnothing(l)
       Lis = unioninds(Lis, l)
     end
-    L, R = factorize(Ã, Lis; kwargs..., tags="Link,n=$n", ortho="left")
+    L, R = factorize(Ã, Lis; kwargs..., tags=tags[n], ortho="left")
     l = commonind(L, R)
     ψ[n] = L
     Ã = R

--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -1907,7 +1907,11 @@ function setindex!(
     end
   end
 
-  linktags = [defaultlinktags(i) for i in firstsite:(lastsite - 1)]
+  # use the first link index if present, otherwise use the default tag
+  linktags = [
+    (b = linkind(ψ, i);
+    isnothing(b) ? defaultlinkindtags(i) : tags(b)) for i in firstsite:(lastsite - 1)
+  ]
   ψA = MPST(
     A,
     sites;

--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -1908,10 +1908,11 @@ function setindex!(
   end
 
   # use the first link index if present, otherwise use the default tag
-  linktags = [
+  linktags = TagSet[
     (b = linkind(ψ, i);
     isnothing(b) ? defaultlinkindtags(i) : tags(b)) for i in firstsite:(lastsite - 1)
   ]
+
   ψA = MPST(
     A,
     sites;

--- a/test/base/test_mps.jl
+++ b/test/base/test_mps.jl
@@ -1424,6 +1424,18 @@ end
     end
   end
 
+  @testset "movesites tags" begin
+    N = 4
+    s0 = siteinds("S=1/2", N)
+    ψ0 = random_mps(s0; linkdims=1)
+    for perm in permutations(1:N)
+      s = s0[perm]
+      ns′ = [findfirst(==(i), s0) for i in s]
+      ψ = movesites(ψ0, 1:N .=> ns′; cutoff=1e-15)
+      @test ITensorMPS.hasdefaultlinktags(ψ)
+    end
+  end
+
   @testset "product(::Vector{ITensor}, ::MPS)" begin
     N = 6
     s = siteinds("Qubit", N)


### PR DESCRIPTION
# Description

The constructor for `AbstractMPS` subtypes now accepts a vector of tags as keyword to be used during the factorization. This is then used by `setindex!(::MPST, ::ITensor, ::UnitRange)` to set the proper inds tags. This fixes #104 Issue, improving readability. 

Fixes #104 

If practical and applicable, please include a minimal demonstration of the previous behavior and new behavior below.

<details><summary>Minimal demonstration of previous behavior</summary><p>

```julia
using ITensorMPS

s = siteinds("Qubit",3)
st = random_mps(s)
stm = movesite(st, 1=>3)

println(stm)
```
Output

MPS
[1] ((dim=2|id=834|"Qubit,Site,n=2"), (dim=2|id=590|"Link,n=1"))
[2] ((dim=2|id=590|"Link,n=1"), (dim=2|id=502|"Qubit,Site,n=3"), (dim=2|id=864|"Link,n=1"))
[3] ((dim=2|id=864|"Link,n=1"), (dim=2|id=138|"Qubit,Site,n=1"))


</p></details>

<details><summary>Minimal demonstration of new behavior</summary><p>
New Output

MPS
[1] ((dim=2|id=384|"Qubit,Site,n=2"), (dim=2|id=128|"Link,l=1"))
[2] ((dim=2|id=128|"Link,l=1"), (dim=2|id=986|"Qubit,Site,n=3"), (dim=2|id=66|"Link,l=2"))
[3] ((dim=2|id=66|"Link,l=2"), (dim=2|id=375|"Qubit,Site,n=1"))


</p></details>

# How Has This Been Tested?

Please add tests that verify your changes to a file in the `test` directory.

Please give a summary of the tests that you added to verify your changes.

- [x] Test over the permutations that `ITensorMPS.hasdefaultlinktags` returns true

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensorMPS`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
