### PR TITLE
[DOCS] Update set_ortho_lims! docs

### DIFF
--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -127,11 +127,11 @@ function ortho_lims(ψ::AbstractMPS)
 end
 
 """
-    ITensors.set_ortho_lims!(::MPS/MPO, r::UnitRange{Int})
+    set_ortho_lims!(::MPS/MPO, r::UnitRange{Int})
 
 Sets the range of sites of the orthogonality center of the MPS/MPO.
 
-This is not exported and is an advanced feature that should be used with
+This is an advanced feature that should be used with
 care. Setting the orthogonality limits wrong can lead to incorrect results
 when using ITensor MPS/MPO functions.
 


### PR DESCRIPTION
Probably the documentation has not been updated after ITensors/ITensorMPS split and the symbol have been exported. Should a docstring be added to `reset_ortho_lims!`? should this one be exported too?
