### PR TITLE
Update references from ITensors to ITensorMPS in documentation and code examples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ITensorMPS"
 uuid = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
-version = "0.3.17"
+version = "0.3.18"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/docs/src/Observer.md
+++ b/docs/src/Observer.md
@@ -84,8 +84,8 @@ end
 ```
 
 (Recall that in order to properly overload the default behavior,
-the `checkdone!` method has to be imported from the ITensors module
-or preceded with `ITensors.`)
+the `checkdone!` method has to be imported from the ITensorMPS module
+or preceded with `ITensorsMPS.`)
 
 
 ### Overloading the `measure!` method

--- a/docs/src/examples/DMRG.md
+++ b/docs/src/examples/DMRG.md
@@ -193,11 +193,11 @@ some helper functions which
 return an array of bonds. Each bond object has an
 "s1" field and an "s2" field which are the integers numbering
 the two sites the bond connects.
-(You can view the source for these functions at [this link](https://github.com/ITensor/ITensors.jl/blob/main/src/lib/ITensorMPS/src/lattices/lattices.jl).)
+(You can view the source for these functions at [this link](https://github.com/ITensor/ITensorMPS.jl/blob/main/src/lattices/lattices.jl).)
 
 The two provided functions currently are `square_lattice` and
 `triangular_lattice`. It is not hard to write your own similar lattice
-functions as all they have to do is define an array of `ITensors.LatticeBond`
+functions as all they have to do is define an array of `ITensorMPS.LatticeBond`
 structs or even a custom struct type you wish to define. We welcome any
 user contributions of other lattices that ITensor does not currently offer.
 

--- a/examples/autodiff/mps_autodiff.jl
+++ b/examples/autodiff/mps_autodiff.jl
@@ -30,9 +30,9 @@ J = 1.0
 h = 0.5
 
 # Loss function only works with `Vector{ITensor}`,
-# extract with `ITensors.data`.
-ψ0 = ITensors.data(random_mps(s; linkdims=10))
-H = ITensors.data(MPO(ising(n; J, h), s))
+# extract with `ITensorMPS.data`.
+ψ0 = ITensorMPS.data(random_mps(s; linkdims=10))
+H = ITensorMPS.data(MPO(ising(n; J, h), s))
 
 loss(ψ) = loss(H, ψ)
 
@@ -46,4 +46,4 @@ Edmrg, ψdmrg = dmrg(MPO(H), MPS(ψ0); nsweeps=10, cutoff=1e-8)
 
 @show loss(ψ0), norm(loss'(ψ0))
 @show loss(ψ), norm(loss'(ψ))
-@show loss(ITensors.data(ψdmrg)), norm(loss'(ITensors.data(ψdmrg)))
+@show loss(ITensorMPS.data(ψdmrg)), norm(loss'(ITensorMPS.data(ψdmrg)))

--- a/ext/ITensorMPSChainRulesCoreExt/abstractmps.jl
+++ b/ext/ITensorMPSChainRulesCoreExt/abstractmps.jl
@@ -179,7 +179,7 @@ function ChainRulesCore.rrule(
   x::Union{MPS,MPO};
   set_limits::Bool=true,
 )
-  y_data, pullback_data = rrule_via_ad(config, map, f, ITensors.data(x))
+  y_data, pullback_data = rrule_via_ad(config, map, f, ITensorMPS.data(x))
   function map_pullback(ȳ)
     dmap, df, dx_data = pullback_data(ȳ)
     return dmap, df, MPS(dx_data)

--- a/src/abstractmps.jl
+++ b/src/abstractmps.jl
@@ -78,7 +78,7 @@ function convert_leaf_eltype(eltype::Type, ψ::AbstractMPS)
 end
 
 """
-    ITensors.data(::MPS/MPO)
+    ITensorMPS.data(::MPS/MPO)
 
 Returns a view of the Vector storage of an MPS/MPO.
 
@@ -127,7 +127,7 @@ function ortho_lims(ψ::AbstractMPS)
 end
 
 """
-    ITensors.set_ortho_lims!(::MPS/MPO, r::UnitRange{Int})
+    ITensorMPS.set_ortho_lims!(::MPS/MPO, r::UnitRange{Int})
 
 Sets the range of sites of the orthogonality center of the MPS/MPO.
 
@@ -378,14 +378,14 @@ end
 #
 
 """
-    ITensors.defaultlinktags(b::Integer)
+    ITensorMPS.defaultlinktags(b::Integer)
 
 Default link tags for link index connecting sites `b` to `b+1`.
 """
 defaultlinktags(b::Integer) = TagSet("Link,l=$b")
 
 """
-    ITensors.hasdefaultlinktags(ψ::MPS/MPO)
+    ITensorMPS.hasdefaultlinktags(ψ::MPS/MPO)
 
 Return true if the MPS/MPO has default link tags.
 """
@@ -400,21 +400,21 @@ function hasdefaultlinktags(ψ::AbstractMPS)
 end
 
 """
-    ITensors.eachlinkinds(ψ::MPS/MPO)
+    ITensorMPS.eachlinkinds(ψ::MPS/MPO)
 
 Return an iterator over each of the sets of link indices of the MPS/MPO.
 """
 eachlinkinds(ψ::AbstractMPS) = (linkinds(ψ, n) for n in eachindex(ψ)[1:(end - 1)])
 
 """
-    ITensors.eachsiteinds(ψ::MPS/MPO)
+    ITensorMPS.eachsiteinds(ψ::MPS/MPO)
 
 Return an iterator over each of the sets of site indices of the MPS/MPO.
 """
 eachsiteinds(ψ::AbstractMPS) = (siteinds(ψ, n) for n in eachindex(ψ))
 
 """
-    ITensors.hasnolinkinds(ψ::MPS/MPO)
+    ITensorMPS.hasnolinkinds(ψ::MPS/MPO)
 
 Return true if the MPS/MPO has no link indices.
 """
@@ -428,7 +428,7 @@ function hasnolinkinds(ψ::AbstractMPS)
 end
 
 """
-    ITensors.insertlinkinds(ψ::MPS/MPO)
+    ITensorMPS.insertlinkinds(ψ::MPS/MPO)
 
 If any link indices are missing, insert default ones.
 """
@@ -1827,7 +1827,7 @@ from decomposing `A` into an MPS or MPO.
 
 The MPS or MPO must be orthogonalized such that
 ```
-firstsite ≤ ITensors.orthocenter(ψ) ≤ lastsite
+firstsite ≤ ITensorMPS.orthocenter(ψ) ≤ lastsite
 ```
 
 Choose the new orthogonality center with `orthocenter`, which

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -12,7 +12,7 @@
 @deprecate multmpo(args...; kwargs...) contract(args...; kwargs...)
 @deprecate set_leftlim!(args...; kwargs...) ITensors.setleftlim!(args...; kwargs...)
 @deprecate set_rightlim!(args...; kwargs...) ITensors.setrightlim!(args...; kwargs...)
-@deprecate tensors(args...; kwargs...) ITensors.data(args...; kwargs...)
+@deprecate tensors(args...; kwargs...) ITensorMPS.data(args...; kwargs...)
 @deprecate primelinks!(args...; kwargs...) ITensors.prime_linkinds!(args...; kwargs...)
 @deprecate simlinks!(args...; kwargs...) ITensors.sim_linkinds!(args...; kwargs...)
 @deprecate mul(A::AbstractMPS, B::AbstractMPS; kwargs...) contract(A, B; kwargs...)

--- a/src/dmrg.jl
+++ b/src/dmrg.jl
@@ -150,7 +150,7 @@ Optional keyword arguments:
 
 [^krylovkit]:
 
-    The `dmrg` function in `ITensors.jl` currently uses the `eigsolve`
+    The `dmrg` function in `ITensorMPS.jl` currently uses the `eigsolve`
     function in `KrylovKit.jl` as the internal the eigensolver.
     See the `KrylovKit.jl` documention on the `eigsolve` function for more details:
     [KrylovKit.eigsolve](https://jutho.github.io/KrylovKit.jl/stable/man/eig/#KrylovKit.eigsolve).

--- a/test/base/test_mpo.jl
+++ b/test/base/test_mpo.jl
@@ -51,7 +51,7 @@ end
   @test hasind(P[1], prime(sites[1]))
   # test constructor from Vector{ITensor}
   K = random_mpo(sites)
-  @test ITensors.data(MPO(copy(ITensors.data(K)))) == ITensors.data(K)
+  @test ITensorMPS.data(MPO(copy(ITensorMPS.data(K)))) == ITensorMPS.data(K)
 
   @testset "orthogonalize!" begin
     phi = random_mps(sites)
@@ -546,7 +546,7 @@ end
     ψ0 = random_mpo(s)
 
     ψ = orthogonalize(ψ0, 2)
-    A = prod(ITensors.data(ψ)[2:(N - 1)])
+    A = prod(ITensorMPS.data(ψ)[2:(N - 1)])
     randn!(A)
     ϕ = MPO(A, s[2:(N - 1)]; orthocenter=1)
     ψ[2:(N - 1)] = ϕ
@@ -555,12 +555,12 @@ end
     @test ITensorMPS.orthocenter(ψ) == 2
 
     ψ = orthogonalize(ψ0, 1)
-    A = prod(ITensors.data(ψ)[2:(N - 1)])
+    A = prod(ITensorMPS.data(ψ)[2:(N - 1)])
     randn!(A)
     @test_throws AssertionError ψ[2:(N - 1)] = A
 
     ψ = orthogonalize(ψ0, 2)
-    A = prod(ITensors.data(ψ)[2:(N - 1)])
+    A = prod(ITensorMPS.data(ψ)[2:(N - 1)])
     randn!(A)
     ψ[2:(N - 1), orthocenter = 3] = A
     @test prod(ψ) ≈ ψ[1] * A * ψ[N]

--- a/test/base/test_qnmpo.jl
+++ b/test/base/test_qnmpo.jl
@@ -52,7 +52,7 @@ end
   L[N] = random_itensor(QN(), dag(sites[N]), sites[N]', dag(links[N - 1]))
 
   @test length(K) == N
-  @test ITensors.data(MPO(copy(ITensors.data(K)))) == ITensors.data(K)
+  @test ITensorMPS.data(MPO(copy(ITensorMPS.data(K)))) == ITensorMPS.data(K)
 
   phi = MPS(N)
   phi[1] = random_itensor(QN(-1), sites[1], links[1])

--- a/test/ext/ITensorMPSChainRulesCoreExt/test_chainrules.jl
+++ b/test/ext/ITensorMPSChainRulesCoreExt/test_chainrules.jl
@@ -89,7 +89,7 @@ Random.seed!(1234)
     @test norm(d_args[1] - 2 * args[1]) ≈ 0 atol = 1e-13
 
     ψ = random_mps(ComplexF64, s)
-    ψtensors = ITensors.data(ψ)
+    ψtensors = ITensorMPS.data(ψ)
     ϕ = random_mps(ComplexF64, s)
     f = function (x)
       ψ̃tensors = [x^j * ψtensors[j] for j in 1:length(ψtensors)]

--- a/test/ext/ITensorMPSChainRulesCoreExt/test_optimization.jl
+++ b/test/ext/ITensorMPSChainRulesCoreExt/test_optimization.jl
@@ -53,8 +53,8 @@ include(joinpath(@__DIR__, "utils", "circuit.jl"))
     Random.seed!(1234)
     ψ₀mps = random_mps(s, n -> isodd(n) ? "↑" : "↓"; linkdims=χ)
 
-    H = ITensors.data(Hmpo)
-    ψ₀ = ITensors.data(ψ₀mps)
+    H = ITensorMPS.data(Hmpo)
+    ψ₀ = ITensorMPS.data(ψ₀mps)
     # The Rayleigh quotient to minimize
     function E(H::Vector{ITensor}, ψ::Vector{ITensor})
       N = length(ψ)


### PR DESCRIPTION
# Description

This mainly updates the docs where `ITensors.` was still used instead of `ITensorMPS.`. In the tests and examples `ITensors.data` has been changed to `ITensorMPS.data` to improve readability.

# Checklist:

- [x] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensorMPS`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that verify the behavior of the changes I made.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
