### PR TITLE
Fix noise term crash in `region_update!`

### DIFF
--- a/src/solvers/sweep_update.jl
+++ b/src/solvers/sweep_update.jl
@@ -414,7 +414,7 @@ function region_update!(
   ortho = isforward(direction) ? "left" : "right"
   drho = nothing
   if noise > 0.0 && isforward(direction)
-    drho = noise * noiseterm(reduced_operator, phi, ortho)
+    drho = noise * noiseterm(reduced_operator, reduced_state, ortho)
   end
   spec = replacebond!(
     state,


### PR DESCRIPTION
# Description

This small change fixes the undefined variable encountered when supplying the `noise` variable to any function using `region_update!`, e.g., `tdvp`.

Fixes #130 