### PR TITLE
Update correlation matrix function

### DIFF
--- a/src/mps.jl
+++ b/src/mps.jl
@@ -896,7 +896,7 @@ function correlation_matrix(
             Li21 *= oᵢ * dag(psi[pL21])'
           else
             sᵢ = siteind(psi, pL21)
-            Li21 *= prime(dag(si[pL21]), !sᵢ)
+            Li21 *= prime(dag(psi[pL21]), !sᵢ)
           end
           Li21 *= psi[pL21]
         end


### PR DESCRIPTION
# Description

The following test function fails with the error as below:

```
function test()

  lat_inds = siteinds("S=1/2", 4);
  state = ["Up" for i=1:4];
  ψ = productMPS(lat_inds, state);

  gates = ITensor[];
  push!(gates, op("H", lat_inds[1]));
  push!(gates, op("CNOT", lat_inds[1], lat_inds[2]));
  push!(gates, op("H", lat_inds[3]));
  push!(gates, op("CNOT", lat_inds[3], lat_inds[4]));
  push!(gates, op("CNOT", lat_inds[2], lat_inds[3]));
  push!(gates, op("H", lat_inds[2]));

  ϕ = apply(gates, ψ; cutoff=1e-8);

  gates_2 = ITensor[op("Proj0", lat_inds[2]), op("Proj0", lat_inds[3])];

  ϕ = apply(gates_2, ϕ; cutoff=1e-8);

  normalize!(ϕ)

  correlation_matrix(ϕ, "Proj0", "Proj0"; sites=[1, 4])
  correlation_matrix(ϕ, "Proj0", "Proj1"; sites=[1, 4])

end
```

While the first `correlation_matrix` works the next one fails with the error:

```
ERROR: UndefVarError: `si` not defined in `ITensorMPS`
Suggestion: check for spelling errors or missing imports.
Stacktrace:
 [1] correlation_matrix(psi::MPS, _Op1::String, _Op2::String; sites::Vector{Int64}, site_range::Nothing, ishermitian::Nothing)
   @ ITensorMPS.jl/src/mps.jl:899
 [2] correlation_matrix
   @ ITensorMPS.jl/src/mps.jl:739 [inlined]
 [3] test()
   @ Main ./REPL[42]:33
 [4] top-level scope
   @ REPL[43]:1
   ```

Fixes #(issue)

Seems like a misspelled `psi` which is fixed in the current PR.

<details><summary>Minimal demonstration of new behavior</summary><p>

Running the above test with the fixed `psi` returns no error.

```julia
[YOUR MINIMAL DEMONSTRATION OF NEW BEHAVIOR]

# Checklist:

- [ ] My code follows the style guidelines of this project. Please run `using JuliaFormatter; format(".")` in the base directory of the repository (`~/.julia/dev/ITensorMPS`) to format your code according to our style guidelines.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have added tests that verify the behavior of the changes I made.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
