### PR TITLE
Fix non-contiguous non-Hermitian correlations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorMPS"
 uuid = "0d1a4710-d33b-49a5-8f18-73bdf49b47e2"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org>", "Miles Stoudenmire <mstoudenmire@flatironinstitute.org>"]
 
 [workspace]

--- a/src/mps.jl
+++ b/src/mps.jl
@@ -907,7 +907,7 @@ function correlation_matrix(
                         Li21 *= oᵢ * dag(psi[pL21])'
                     else
                         sᵢ = siteind(psi, pL21)
-                        Li21 *= prime(dag(si[pL21]), !sᵢ)
+                        Li21 *= prime(dag(psi[pL21]), !sᵢ)
                     end
                     Li21 *= psi[pL21]
                 end

--- a/test/base/test_mps.jl
+++ b/test/base/test_mps.jl
@@ -1004,6 +1004,9 @@ end
 
         @test norm(PM[range] - expect(psi, "S+ * S-"; sites = range)) < 1.0e-8
 
+        # Regression test for https://github.com/ITensor/ITensorMPS.jl/pull/221:
+        # non-contiguous sites with `ishermitian=false` exercise the lower-triangle
+        # contraction path through skipped MPS tensors.
         non_contiguous = [1, 3, 8]
         C = correlation_matrix(psi, "Sz", "Sx"; ishermitian = false)
         Cs =

--- a/test/base/test_mps.jl
+++ b/test/base/test_mps.jl
@@ -1004,6 +1004,14 @@ end
 
         @test norm(PM[range] - expect(psi, "S+ * S-"; sites = range)) < 1.0e-8
 
+        non_contiguous = [1, 3, 8]
+        C = correlation_matrix(psi, "Sz", "Sx"; ishermitian = false)
+        Cs =
+            correlation_matrix(psi, "Sz", "Sx"; sites = non_contiguous, ishermitian = false)
+        for (ni, i) in enumerate(non_contiguous), (nj, j) in enumerate(non_contiguous)
+            @test Cs[ni, nj] ≈ C[i, j]
+        end
+
         # With start_site, end_site arguments:
         s = siteinds("S=1/2", 8)
         psi = random_mps(ComplexF64, s; linkdims = m)


### PR DESCRIPTION
## Summary
- Fix a typo in the lower-triangle `correlation_matrix` update for non-Hermitian bosonic correlations over non-contiguous site selections.
- Add regression coverage comparing a non-contiguous `sites` result against the corresponding full correlation matrix entries.
- Bump the patch version for the library change.

Fixes #220.